### PR TITLE
Dev/fix passkey using

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,70 +1,38 @@
 # Migration Guide - Fix User ID Resolution
 
-## Problème Résolu
+## Problem Resolved
 
-Le système avait un problème où les identifiants utilisateurs n'étaient pas correctement récupérés lors de l'authentification. Cela causait des erreurs "User not found" ou des incohérences d'ID.
+The system had an issue where user identifiers were not correctly retrieved during authentication. This caused "User not found" errors or ID inconsistencies.
 
-## Changements Effectués
+## Changes Made
 
-### 1. Interface de Stockage (`storage.ts`)
+### 1. Memory Storage (`memory-storage.ts`)
 
-Ajout d'une nouvelle méthode pour récupérer les challenges par leur valeur :
+- Improved challenge storage to use consistent keys (username or empty string for usernameless flows)
+- Enhanced cleanup of expired challenges
 
-```typescript
-getAndDeleteChallengeByValue(challengeValue: string): Promise<Challenge | null>;
-```
+### 2. Passkey Service (`passkey-service.ts`)
 
-### 2. Stockage en Mémoire (`memory-storage.ts`)
+#### Registration
 
-- Ajout d'un double index pour les challenges (par username ET par valeur du challenge)
-- Implémentation de la nouvelle méthode `getAndDeleteChallengeByValue`
-- Amélioration du nettoyage des challenges expirés pour gérer les deux index
+- Ensured the challenge `userId` is used consistently
+- If the user already exists, their existing `userId` is reused
 
-### 3. Service Passkey (`passkey-service.ts`)
+#### Authentication
 
-#### Enregistrement
+- Retrieved user via `getUserByCredentialId` first
+- Fixed challenge retrieval for usernameless authentication flows
+- Challenge is now correctly retrieved using the same key it was saved with (empty string for usernameless, or the provided username)
 
-- Garantie que le `userId` du challenge est utilisé de manière cohérente
-- Si l'utilisateur existe déjà, on réutilise son `userId` existant
+## Migration for Custom Implementations
 
-#### Authentification
+If you have implemented the `PasskeyStorage` interface with your own database, you need to ensure proper challenge storage:
 
-- Récupération de l'utilisateur via `getUserByCredentialId` en premier
-- Utilisation du username réel de l'utilisateur trouvé pour récupérer le challenge
-- Support amélioré pour l'authentification découvrable (sans username)
+### Optimize challenge storage
 
-## Migration pour les Implémentations Personnalisées
+Challenges should be stored and retrieved by username. For usernameless (discoverable) authentication, an empty string is used as the key.
 
-Si vous avez implémenté l'interface `PasskeyStorage` avec votre propre base de données, vous devez :
-
-### 1. Ajouter la nouvelle méthode
-
-```typescript
-async getAndDeleteChallengeByValue(challengeValue: string): Promise<Challenge | null> {
-  // Récupérer le challenge par sa valeur
-  const challenge = await db.challenge.findUnique({
-    where: { challenge: challengeValue }
-  });
-
-  if (challenge) {
-    // Supprimer le challenge (usage unique)
-    await db.challenge.delete({
-      where: { challenge: challengeValue }
-    });
-  }
-
-  return challenge;
-}
-```
-
-### 2. Optimiser le stockage des challenges
-
-Il est recommandé de pouvoir récupérer un challenge soit par :
-
-- Le username de l'utilisateur (pour les authentifications standard)
-- La valeur du challenge (pour les authentifications découvrables)
-
-**Exemple avec Prisma :**
+**Example with Prisma:**
 
 ```prisma
 model Challenge {
@@ -80,44 +48,44 @@ model Challenge {
 }
 ```
 
-### 3. Garantir la cohérence des userId
+### Ensure userId consistency
 
-Assurez-vous que :
+Make sure that:
 
-- Le `userId` généré lors de l'enregistrement est unique et persistant
-- Le même `userId` est toujours retourné pour le même utilisateur
-- L'index `credentialId -> userId` permet de retrouver rapidement l'utilisateur
+- The `userId` generated during registration is unique and persistent
+- The same `userId` is always returned for the same user
+- The `credentialId -> userId` index allows quick user retrieval
 
-## Tests Recommandés
+## Recommended Tests
 
-Après migration, testez les scénarios suivants :
+After migration, test the following scenarios:
 
-1. **Enregistrement d'un nouvel utilisateur**
+1. **Registering a new user**
 
-   - Vérifiez que le `userId` est généré et sauvegardé
-   - Vérifiez que le credential est correctement indexé
+   - Verify that the `userId` is generated and saved
+   - Verify that the credential is properly indexed
 
-2. **Authentification avec username**
+2. **Authentication with username**
 
-   - Vérifiez que le challenge est trouvé
-   - Vérifiez que l'utilisateur est correctement identifié
-   - Vérifiez que le `userId` retourné correspond à celui de l'enregistrement
+   - Verify that the challenge is found
+   - Verify that the user is correctly identified
+   - Verify that the returned `userId` matches the one from registration
 
-3. **Authentification découvrable (sans username)**
+3. **Discoverable authentication (without username)**
 
-   - Vérifiez que l'utilisateur est trouvé via le credentialId
-   - Vérifiez que le challenge est récupéré
-   - Vérifiez que le `userId` est cohérent
+   - Verify that the user is found via credentialId
+   - Verify that the challenge is retrieved correctly
+   - Verify that the `userId` is consistent
 
-4. **Ajout d'une seconde passkey**
-   - Vérifiez que l'utilisateur existant est mis à jour
-   - Vérifiez que le `userId` reste le même
-   - Vérifiez que les deux credentials sont indexés
+4. **Adding a second passkey**
+   - Verify that the existing user is updated
+   - Verify that the `userId` remains the same
+   - Verify that both credentials are indexed
 
 ## Support
 
-Si vous rencontrez des problèmes lors de la migration, vérifiez :
+If you encounter issues during migration, check that:
 
-- Que votre implémentation de `PasskeyStorage` inclut toutes les méthodes requises
-- Que les index de base de données sont correctement configurés
-- Que les challenges expirés sont régulièrement nettoyés
+- Your `PasskeyStorage` implementation includes all required methods
+- Database indexes are properly configured
+- Expired challenges are regularly cleaned up

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,123 @@
+# Migration Guide - Fix User ID Resolution
+
+## Problème Résolu
+
+Le système avait un problème où les identifiants utilisateurs n'étaient pas correctement récupérés lors de l'authentification. Cela causait des erreurs "User not found" ou des incohérences d'ID.
+
+## Changements Effectués
+
+### 1. Interface de Stockage (`storage.ts`)
+
+Ajout d'une nouvelle méthode pour récupérer les challenges par leur valeur :
+
+```typescript
+getAndDeleteChallengeByValue(challengeValue: string): Promise<Challenge | null>;
+```
+
+### 2. Stockage en Mémoire (`memory-storage.ts`)
+
+- Ajout d'un double index pour les challenges (par username ET par valeur du challenge)
+- Implémentation de la nouvelle méthode `getAndDeleteChallengeByValue`
+- Amélioration du nettoyage des challenges expirés pour gérer les deux index
+
+### 3. Service Passkey (`passkey-service.ts`)
+
+#### Enregistrement
+
+- Garantie que le `userId` du challenge est utilisé de manière cohérente
+- Si l'utilisateur existe déjà, on réutilise son `userId` existant
+
+#### Authentification
+
+- Récupération de l'utilisateur via `getUserByCredentialId` en premier
+- Utilisation du username réel de l'utilisateur trouvé pour récupérer le challenge
+- Support amélioré pour l'authentification découvrable (sans username)
+
+## Migration pour les Implémentations Personnalisées
+
+Si vous avez implémenté l'interface `PasskeyStorage` avec votre propre base de données, vous devez :
+
+### 1. Ajouter la nouvelle méthode
+
+```typescript
+async getAndDeleteChallengeByValue(challengeValue: string): Promise<Challenge | null> {
+  // Récupérer le challenge par sa valeur
+  const challenge = await db.challenge.findUnique({
+    where: { challenge: challengeValue }
+  });
+
+  if (challenge) {
+    // Supprimer le challenge (usage unique)
+    await db.challenge.delete({
+      where: { challenge: challengeValue }
+    });
+  }
+
+  return challenge;
+}
+```
+
+### 2. Optimiser le stockage des challenges
+
+Il est recommandé de pouvoir récupérer un challenge soit par :
+
+- Le username de l'utilisateur (pour les authentifications standard)
+- La valeur du challenge (pour les authentifications découvrables)
+
+**Exemple avec Prisma :**
+
+```prisma
+model Challenge {
+  id          String   @id @default(cuid())
+  challenge   String   @unique
+  userId      String
+  username    String
+  createdAt   DateTime
+  expiresAt   DateTime
+
+  @@index([username])
+  @@index([challenge])
+}
+```
+
+### 3. Garantir la cohérence des userId
+
+Assurez-vous que :
+
+- Le `userId` généré lors de l'enregistrement est unique et persistant
+- Le même `userId` est toujours retourné pour le même utilisateur
+- L'index `credentialId -> userId` permet de retrouver rapidement l'utilisateur
+
+## Tests Recommandés
+
+Après migration, testez les scénarios suivants :
+
+1. **Enregistrement d'un nouvel utilisateur**
+
+   - Vérifiez que le `userId` est généré et sauvegardé
+   - Vérifiez que le credential est correctement indexé
+
+2. **Authentification avec username**
+
+   - Vérifiez que le challenge est trouvé
+   - Vérifiez que l'utilisateur est correctement identifié
+   - Vérifiez que le `userId` retourné correspond à celui de l'enregistrement
+
+3. **Authentification découvrable (sans username)**
+
+   - Vérifiez que l'utilisateur est trouvé via le credentialId
+   - Vérifiez que le challenge est récupéré
+   - Vérifiez que le `userId` est cohérent
+
+4. **Ajout d'une seconde passkey**
+   - Vérifiez que l'utilisateur existant est mis à jour
+   - Vérifiez que le `userId` reste le même
+   - Vérifiez que les deux credentials sont indexés
+
+## Support
+
+Si vous rencontrez des problèmes lors de la migration, vérifiez :
+
+- Que votre implémentation de `PasskeyStorage` inclut toutes les méthodes requises
+- Que les index de base de données sont correctement configurés
+- Que les challenges expirés sont régulièrement nettoyés

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,7 +9,7 @@ The system had an issue where user identifiers were not correctly retrieved duri
 ### 1. Memory Storage (`memory-storage.ts`)
 
 - Improved challenge storage to use consistent keys (username or empty string for usernameless flows)
-- Enhanced cleanup of expired challenges
+- Simplified cleanup of expired challenges to match the streamlined storage structure
 
 ### 2. Passkey Service (`passkey-service.ts`)
 
@@ -27,6 +27,14 @@ The system had an issue where user identifiers were not correctly retrieved duri
 ## Migration for Custom Implementations
 
 If you have implemented the `PasskeyStorage` interface with your own database, you need to ensure proper challenge storage:
+
+### Breaking Change: Remove getAndDeleteChallengeByValue
+
+The `getAndDeleteChallengeByValue` method has been removed from the `PasskeyStorage` interface as it was never used. If you previously implemented this method, you should:
+
+1. Remove the `getAndDeleteChallengeByValue` method from your storage implementation
+2. Remove any dual-indexing logic (e.g., indexing challenges by both username and challenge value)
+3. Simplify your challenge storage to only index by username
 
 ### Optimize challenge storage
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Passkeys require WebAuthn support:
 
 This system is configured to work with modern **passkey** implementations and WebAuthn-compatible authenticators. In practice, this means users can:
 - Create a passkey on a device (e.g., Mac with Touch ID or an Android phone)
-- Use that passkey on other devices **within the same credential ecosystem** (e.g., Mac → iPhone via iCloud Keychain, Android phone → Chrome on another Android device or ChromeOS via Google Password Manager)
+- Use that passkey on other devices **within the same credential ecosystem** (e.g., Mac → iPhone via iCloud Keychain, Android phone → Chrome on another Android device or on ChromeOS via Google Password Manager)
 - Sync passkeys across supported devices via iCloud Keychain, Google Password Manager, or other credential managers that participate in the same ecosystem
 
 Note that passkeys generally **do not sync between different ecosystems** (for example, a passkey created in iCloud Keychain on a Mac cannot automatically be used on an unrelated Android device that only uses Google Password Manager). For true cross-platform use across ecosystems, users can instead use **cross-platform authenticators** such as compatible hardware security keys.

--- a/README.md
+++ b/README.md
@@ -194,14 +194,16 @@ Passkeys require WebAuthn support:
 | Firefox | 60+ |
 | Safari | 13+ |
 
-### Cross-Platform Passkeys
+### Passkeys and Cross-Device Usage
 
-This system is configured for **cross-platform passkey support**, allowing users to:
-- Create a passkey on one device (e.g., Mac with Touch ID)
-- Use that passkey on another device (e.g., Android phone)
-- Sync passkeys across devices via iCloud Keychain, Google Password Manager, or other credential managers
+This system is configured to work with modern **passkey** implementations and WebAuthn-compatible authenticators. In practice, this means users can:
+- Create a passkey on a device (e.g., Mac with Touch ID or an Android phone)
+- Use that passkey on other devices **within the same credential ecosystem** (e.g., Mac → iPhone via iCloud Keychain, Android phone → Chrome on another Android device or ChromeOS via Google Password Manager)
+- Sync passkeys across supported devices via iCloud Keychain, Google Password Manager, or other credential managers that participate in the same ecosystem
 
-The system uses `residentKey: "required"` to ensure credentials are properly stored on the authenticator and can be synced across your devices.
+Note that passkeys generally **do not sync between different ecosystems** (for example, a passkey created in iCloud Keychain on a Mac cannot automatically be used on an unrelated Android device that only uses Google Password Manager). For true cross‑platform use across ecosystems, users can instead use **cross‑platform authenticators** such as compatible hardware security keys.
+
+The system uses `residentKey: "required"` to create **resident (discoverable) credentials**, which enables usernameless / account‑selection flows on supported authenticators. This setting controls how credentials are stored and discovered on the authenticator; it does **not** itself provide cross‑ecosystem syncing.
 
 ## 🔐 Security
 

--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ This system is configured to work with modern **passkey** implementations and We
 - Use that passkey on other devices **within the same credential ecosystem** (e.g., Mac → iPhone via iCloud Keychain, Android phone → Chrome on another Android device or ChromeOS via Google Password Manager)
 - Sync passkeys across supported devices via iCloud Keychain, Google Password Manager, or other credential managers that participate in the same ecosystem
 
-Note that passkeys generally **do not sync between different ecosystems** (for example, a passkey created in iCloud Keychain on a Mac cannot automatically be used on an unrelated Android device that only uses Google Password Manager). For true cross‑platform use across ecosystems, users can instead use **cross‑platform authenticators** such as compatible hardware security keys.
+Note that passkeys generally **do not sync between different ecosystems** (for example, a passkey created in iCloud Keychain on a Mac cannot automatically be used on an unrelated Android device that only uses Google Password Manager). For true cross-platform use across ecosystems, users can instead use **cross-platform authenticators** such as compatible hardware security keys.
 
-The system uses `residentKey: "required"` to create **resident (discoverable) credentials**, which enables usernameless / account‑selection flows on supported authenticators. This setting controls how credentials are stored and discovered on the authenticator; it does **not** itself provide cross‑ecosystem syncing.
+The system uses `residentKey: "required"` to create **resident (discoverable) credentials**, which enables usernameless / account-selection flows on supported authenticators. This setting controls how credentials are stored and discovered on the authenticator; it does **not** itself provide cross-ecosystem syncing.
 
 ## 🔐 Security
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,15 @@ Passkeys require WebAuthn support:
 | Firefox | 60+ |
 | Safari | 13+ |
 
+### Cross-Platform Passkeys
+
+This system is configured for **cross-platform passkey support**, allowing users to:
+- Create a passkey on one device (e.g., Mac with Touch ID)
+- Use that passkey on another device (e.g., Android phone)
+- Sync passkeys across devices via iCloud Keychain, Google Password Manager, or other credential managers
+
+The system uses `residentKey: "required"` to ensure credentials are properly stored on the authenticator and can be synced across your devices.
+
 ## 🔐 Security
 
 This system implements WebAuthn best practices:

--- a/api/README.md
+++ b/api/README.md
@@ -5,6 +5,7 @@ Serverless API for passkey authentication built with Next.js.
 ## Features
 
 - 🔐 Complete WebAuthn implementation
+- 🌍 Cross-platform passkey support (sync across devices)
 - 🚀 Serverless-ready (Vercel, Netlify, AWS Lambda, etc.)
 - 🔌 Pluggable storage interface
 - 📝 TypeScript support

--- a/api/README.md
+++ b/api/README.md
@@ -5,7 +5,7 @@ Serverless API for passkey authentication built with Next.js.
 ## Features
 
 - 🔐 Complete WebAuthn implementation
-- 🌍 Cross-platform passkey support (sync across devices)
+- 🌍 Resident passkey support for usernameless authentication (sync within credential manager ecosystems)
 - 🚀 Serverless-ready (Vercel, Netlify, AWS Lambda, etc.)
 - 🔌 Pluggable storage interface
 - 📝 TypeScript support

--- a/api/src/lib/memory-storage.ts
+++ b/api/src/lib/memory-storage.ts
@@ -23,7 +23,6 @@ export class MemoryStorage implements PasskeyStorage {
   private users: Map<string, UserPasskey> = new Map();
   private credentialIndex: Map<string, string> = new Map(); // credentialId -> username
   private challenges: Map<string, Challenge> = new Map(); // username -> challenge
-  private challengesByValue: Map<string, Challenge> = new Map(); // challenge -> Challenge
 
   constructor() {
     if (process.env.NODE_ENV === "production") {
@@ -96,26 +95,13 @@ export class MemoryStorage implements PasskeyStorage {
   }
 
   async saveChallenge(challenge: Challenge): Promise<void> {
-    this.challenges.set(challenge.username || challenge.challenge, challenge);
-    this.challengesByValue.set(challenge.challenge, challenge);
+    this.challenges.set(challenge.username, challenge);
   }
 
   async getAndDeleteChallenge(username: string): Promise<Challenge | null> {
     const challenge = this.challenges.get(username) || null;
     if (challenge) {
       this.challenges.delete(username);
-      this.challengesByValue.delete(challenge.challenge);
-    }
-    return challenge;
-  }
-
-  async getAndDeleteChallengeByValue(
-    challengeValue: string
-  ): Promise<Challenge | null> {
-    const challenge = this.challengesByValue.get(challengeValue) || null;
-    if (challenge) {
-      this.challengesByValue.delete(challengeValue);
-      this.challenges.delete(challenge.username || challengeValue);
     }
     return challenge;
   }
@@ -125,7 +111,6 @@ export class MemoryStorage implements PasskeyStorage {
     for (const [key, challenge] of this.challenges.entries()) {
       if (challenge.expiresAt < now) {
         this.challenges.delete(key);
-        this.challengesByValue.delete(challenge.challenge);
       }
     }
   }

--- a/api/src/lib/memory-storage.ts
+++ b/api/src/lib/memory-storage.ts
@@ -1,14 +1,14 @@
 /**
  * In-memory storage implementation
- * 
+ *
  * ⚠️ WARNING: FOR DEVELOPMENT/TESTING ONLY ⚠️
- * 
+ *
  * This storage implementation:
  * - Stores all data in memory (lost on server restart)
  * - Does not persist across multiple instances
  * - Is NOT suitable for production use
  * - Should ONLY be used for local development and testing
- * 
+ *
  * For production, implement the PasskeyStorage interface with a proper database.
  */
 
@@ -17,19 +17,20 @@ import type {
   UserPasskey,
   PasskeyCredential,
   Challenge,
-} from './storage';
+} from "./storage";
 
 export class MemoryStorage implements PasskeyStorage {
   private users: Map<string, UserPasskey> = new Map();
   private credentialIndex: Map<string, string> = new Map(); // credentialId -> username
   private challenges: Map<string, Challenge> = new Map(); // username -> challenge
+  private challengesByValue: Map<string, Challenge> = new Map(); // challenge -> Challenge
 
   constructor() {
-    if (process.env.NODE_ENV === 'production') {
-      const errorMsg = 
-        '❌ CRITICAL ERROR: MemoryStorage is being used in production! ' +
-        'This will cause data loss and security vulnerabilities. ' +
-        'You must implement the PasskeyStorage interface with a proper database.';
+    if (process.env.NODE_ENV === "production") {
+      const errorMsg =
+        "❌ CRITICAL ERROR: MemoryStorage is being used in production! " +
+        "This will cause data loss and security vulnerabilities. " +
+        "You must implement the PasskeyStorage interface with a proper database.";
       console.error(errorMsg);
       throw new Error(errorMsg);
     }
@@ -47,16 +48,21 @@ export class MemoryStorage implements PasskeyStorage {
     return this.users.get(username) || null;
   }
 
-  async getUserByCredentialId(credentialId: string): Promise<UserPasskey | null> {
+  async getUserByCredentialId(
+    credentialId: string
+  ): Promise<UserPasskey | null> {
     const username = this.credentialIndex.get(credentialId);
     if (!username) return null;
     return this.users.get(username) || null;
   }
 
-  async addCredential(username: string, credential: PasskeyCredential): Promise<void> {
+  async addCredential(
+    username: string,
+    credential: PasskeyCredential
+  ): Promise<void> {
     const user = this.users.get(username);
     if (!user) {
-      throw new Error('User not found');
+      throw new Error("User not found");
     }
 
     user.credentials.push(credential);
@@ -65,20 +71,23 @@ export class MemoryStorage implements PasskeyStorage {
     this.users.set(username, user);
   }
 
-  async updateCredentialCounter(credentialId: string, counter: number): Promise<void> {
+  async updateCredentialCounter(
+    credentialId: string,
+    counter: number
+  ): Promise<void> {
     const username = this.credentialIndex.get(credentialId);
     if (!username) {
-      throw new Error('Credential not found');
+      throw new Error("Credential not found");
     }
 
     const user = this.users.get(username);
     if (!user) {
-      throw new Error('User not found');
+      throw new Error("User not found");
     }
 
     const credential = user.credentials.find((c) => c.id === credentialId);
     if (!credential) {
-      throw new Error('Credential not found');
+      throw new Error("Credential not found");
     }
 
     credential.counter = counter;
@@ -87,22 +96,36 @@ export class MemoryStorage implements PasskeyStorage {
   }
 
   async saveChallenge(challenge: Challenge): Promise<void> {
-    this.challenges.set(challenge.username, challenge);
+    this.challenges.set(challenge.username || challenge.challenge, challenge);
+    this.challengesByValue.set(challenge.challenge, challenge);
   }
 
   async getAndDeleteChallenge(username: string): Promise<Challenge | null> {
     const challenge = this.challenges.get(username) || null;
     if (challenge) {
       this.challenges.delete(username);
+      this.challengesByValue.delete(challenge.challenge);
+    }
+    return challenge;
+  }
+
+  async getAndDeleteChallengeByValue(
+    challengeValue: string
+  ): Promise<Challenge | null> {
+    const challenge = this.challengesByValue.get(challengeValue) || null;
+    if (challenge) {
+      this.challengesByValue.delete(challengeValue);
+      this.challenges.delete(challenge.username || challengeValue);
     }
     return challenge;
   }
 
   async cleanupExpiredChallenges(): Promise<void> {
     const now = new Date();
-    for (const [username, challenge] of this.challenges.entries()) {
+    for (const [key, challenge] of this.challenges.entries()) {
       if (challenge.expiresAt < now) {
-        this.challenges.delete(username);
+        this.challenges.delete(key);
+        this.challengesByValue.delete(challenge.challenge);
       }
     }
   }

--- a/api/src/lib/passkey-service.ts
+++ b/api/src/lib/passkey-service.ts
@@ -59,7 +59,7 @@ export class PasskeyService {
       attestationType: 'none',
       excludeCredentials,
       authenticatorSelection: {
-        residentKey: 'preferred',
+        residentKey: 'required',
         userVerification: 'preferred',
       },
     });

--- a/api/src/lib/passkey-service.ts
+++ b/api/src/lib/passkey-service.ts
@@ -147,7 +147,7 @@ export class PasskeyService {
       userVerification: "preferred",
     });
 
-    // Save challenge with a unique key using the challenge itself
+    // Save challenge associated with the (optional) username for later verification
     await this.storage.saveChallenge({
       challenge: options.challenge,
       userId: "", // Will be determined during verification
@@ -169,10 +169,10 @@ export class PasskeyService {
       throw new Error("User not found");
     }
 
-    // Use the actual username from the found user to get the challenge
-    const challenge = await this.storage.getAndDeleteChallenge(
-      username || user.username
-    );
+    // For usernameless flows, the challenge was saved with empty string
+    // For username flows, the challenge was saved with the provided username
+    const challengeKey = username !== undefined ? username : "";
+    const challenge = await this.storage.getAndDeleteChallenge(challengeKey);
     if (!challenge) {
       throw new Error("Challenge not found or expired");
     }

--- a/api/src/lib/passkey-service.ts
+++ b/api/src/lib/passkey-service.ts
@@ -7,10 +7,10 @@ import {
   verifyRegistrationResponse,
   generateAuthenticationOptions,
   verifyAuthenticationResponse,
-} from '@simplewebauthn/server';
-import { randomBytes } from 'crypto';
-import type { PasskeyStorage, PasskeyCredential } from './storage';
-import { memoryStorage } from './memory-storage';
+} from "@simplewebauthn/server";
+import { randomBytes } from "crypto";
+import type { PasskeyStorage, PasskeyCredential } from "./storage";
+import { memoryStorage } from "./memory-storage";
 
 export interface PasskeyServiceConfig {
   rpName: string;
@@ -25,7 +25,7 @@ export class PasskeyService {
 
   constructor(config: PasskeyServiceConfig) {
     this.config = {
-      rpName: config.rpName || 'Passkey Demo',
+      rpName: config.rpName || "Passkey Demo",
       rpID: config.rpID,
       origin: config.origin,
     };
@@ -44,11 +44,12 @@ export class PasskeyService {
 
     // Check if user exists
     const existingUser = await this.storage.getUserByUsername(username);
-    const excludeCredentials = existingUser?.credentials.map((cred) => ({
-      id: Buffer.from(cred.id, 'base64url'),
-      type: 'public-key' as const,
-      transports: cred.transports as AuthenticatorTransport[] | undefined,
-    })) || [];
+    const excludeCredentials =
+      existingUser?.credentials.map((cred) => ({
+        id: Buffer.from(cred.id, "base64url"),
+        type: "public-key" as const,
+        transports: cred.transports as AuthenticatorTransport[] | undefined,
+      })) || [];
 
     const options = await generateRegistrationOptions({
       rpName: this.config.rpName,
@@ -56,11 +57,11 @@ export class PasskeyService {
       userID: userIdToUse,
       userName: username,
       userDisplayName: displayName,
-      attestationType: 'none',
+      attestationType: "none",
       excludeCredentials,
       authenticatorSelection: {
-        residentKey: 'required',
-        userVerification: 'preferred',
+        residentKey: "required",
+        userVerification: "preferred",
       },
     });
 
@@ -79,13 +80,10 @@ export class PasskeyService {
   /**
    * Verify registration response
    */
-  async verifyRegistration(
-    username: string,
-    response: any
-  ) {
+  async verifyRegistration(username: string, response: any) {
     const challenge = await this.storage.getAndDeleteChallenge(username);
     if (!challenge) {
-      throw new Error('Challenge not found or expired');
+      throw new Error("Challenge not found or expired");
     }
 
     const verification = await verifyRegistrationResponse({
@@ -96,15 +94,16 @@ export class PasskeyService {
     });
 
     if (!verification.verified || !verification.registrationInfo) {
-      throw new Error('Registration verification failed');
+      throw new Error("Registration verification failed");
     }
 
-    const { credentialID, credentialPublicKey, counter } = verification.registrationInfo;
+    const { credentialID, credentialPublicKey, counter } =
+      verification.registrationInfo;
 
     // Create credential
     const credential: PasskeyCredential = {
-      id: Buffer.from(credentialID).toString('base64url'),
-      publicKey: Buffer.from(credentialPublicKey).toString('base64url'),
+      id: Buffer.from(credentialID).toString("base64url"),
+      publicKey: Buffer.from(credentialPublicKey).toString("base64url"),
       counter,
       transports: response.response.transports,
       createdAt: new Date(),
@@ -112,11 +111,13 @@ export class PasskeyService {
 
     // Save or update user
     const existingUser = await this.storage.getUserByUsername(username);
+    const userId = existingUser ? existingUser.userId : challenge.userId;
+
     if (existingUser) {
       await this.storage.addCredential(username, credential);
     } else {
       await this.storage.saveUser({
-        userId: challenge.userId,
+        userId: userId,
         username,
         displayName: username,
         credentials: [credential],
@@ -127,7 +128,7 @@ export class PasskeyService {
 
     return {
       verified: true,
-      userId: challenge.userId,
+      userId: userId,
       credentialId: credential.id,
     };
   }
@@ -143,14 +144,14 @@ export class PasskeyService {
     const options = await generateAuthenticationOptions({
       rpID: this.config.rpID,
       allowCredentials,
-      userVerification: 'preferred',
+      userVerification: "preferred",
     });
 
-    // Save challenge
+    // Save challenge with a unique key using the challenge itself
     await this.storage.saveChallenge({
       challenge: options.challenge,
-      userId: '', // Will be determined during verification
-      username: username || '',
+      userId: "", // Will be determined during verification
+      username: username || "",
       createdAt: new Date(),
       expiresAt: new Date(Date.now() + 5 * 60 * 1000), // 5 minutes
     });
@@ -161,25 +162,25 @@ export class PasskeyService {
   /**
    * Verify authentication response
    */
-  async verifyAuthentication(
-    username: string | undefined,
-    response: any
-  ) {
-    const challenge = await this.storage.getAndDeleteChallenge(username || '');
-    if (!challenge) {
-      throw new Error('Challenge not found or expired');
-    }
-
-    // Get user by credential ID
+  async verifyAuthentication(username: string | undefined, response: any) {
+    // Get user by credential ID first
     const user = await this.storage.getUserByCredentialId(response.id);
     if (!user) {
-      throw new Error('User not found');
+      throw new Error("User not found");
+    }
+
+    // Use the actual username from the found user to get the challenge
+    const challenge = await this.storage.getAndDeleteChallenge(
+      username || user.username
+    );
+    if (!challenge) {
+      throw new Error("Challenge not found or expired");
     }
 
     // Find the credential
     const credential = user.credentials.find((c) => c.id === response.id);
     if (!credential) {
-      throw new Error('Credential not found');
+      throw new Error("Credential not found");
     }
 
     // Verify authentication
@@ -189,14 +190,14 @@ export class PasskeyService {
       expectedOrigin: this.config.origin,
       expectedRPID: this.config.rpID,
       authenticator: {
-        credentialID: Buffer.from(credential.id, 'base64url'),
-        credentialPublicKey: Buffer.from(credential.publicKey, 'base64url'),
+        credentialID: Buffer.from(credential.id, "base64url"),
+        credentialPublicKey: Buffer.from(credential.publicKey, "base64url"),
         counter: credential.counter,
       },
     });
 
     if (!verification.verified) {
-      throw new Error('Authentication verification failed');
+      throw new Error("Authentication verification failed");
     }
 
     // Update counter
@@ -222,8 +223,8 @@ export class PasskeyService {
     }
 
     return user.credentials.map((cred) => ({
-      id: Buffer.from(cred.id, 'base64url'),
-      type: 'public-key' as const,
+      id: Buffer.from(cred.id, "base64url"),
+      type: "public-key" as const,
       transports: cred.transports as AuthenticatorTransport[] | undefined,
     }));
   }
@@ -235,6 +236,6 @@ export class PasskeyService {
    */
   private generateUserId(): string {
     // Use Node.js crypto module for random bytes
-    return randomBytes(32).toString('base64url');
+    return randomBytes(32).toString("base64url");
   }
 }

--- a/api/src/lib/storage.ts
+++ b/api/src/lib/storage.ts
@@ -65,13 +65,6 @@ export interface PasskeyStorage {
   getAndDeleteChallenge(username: string): Promise<Challenge | null>;
 
   /**
-   * Get and delete a challenge by challenge string (single-use)
-   */
-  getAndDeleteChallengeByValue(
-    challengeValue: string
-  ): Promise<Challenge | null>;
-
-  /**
    * Clean up expired challenges
    */
   cleanupExpiredChallenges(): Promise<void>;

--- a/api/src/lib/storage.ts
+++ b/api/src/lib/storage.ts
@@ -60,9 +60,16 @@ export interface PasskeyStorage {
   saveChallenge(challenge: Challenge): Promise<void>;
 
   /**
-   * Get and delete a challenge (single-use)
+   * Get and delete a challenge by username (single-use)
    */
   getAndDeleteChallenge(username: string): Promise<Challenge | null>;
+
+  /**
+   * Get and delete a challenge by challenge string (single-use)
+   */
+  getAndDeleteChallengeByValue(
+    challengeValue: string
+  ): Promise<Challenge | null>;
 
   /**
    * Clean up expired challenges

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -67,7 +67,7 @@ Generate options for registering a new passkey.
   "timeout": 60000,
   "excludeCredentials": [],
   "authenticatorSelection": {
-    "residentKey": "preferred",
+    "residentKey": "required",
     "userVerification": "preferred"
   },
   "attestation": "none"

--- a/docs/guide-without-api.md
+++ b/docs/guide-without-api.md
@@ -89,7 +89,7 @@ app.post('/api/passkey/register/options', async (req, res) => {
     userDisplayName: displayName,
     attestationType: 'none',
     authenticatorSelection: {
-      residentKey: 'preferred',
+      residentKey: 'required',
       userVerification: 'preferred',
     },
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1129,7 +1129,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1436,7 +1435,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1903,7 +1901,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1952,7 +1949,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -2034,7 +2030,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2047,7 +2042,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2339,7 +2333,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2380,7 +2373,7 @@
     },
     "package": {
       "name": "@jeremiemeunier/passkey",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@simplewebauthn/browser": "^9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1129,6 +1129,7 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1435,6 +1436,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1901,6 +1903,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1949,6 +1952,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -2030,6 +2034,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2042,6 +2047,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2333,6 +2339,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2373,7 +2380,7 @@
     },
     "package": {
       "name": "@jeremiemeunier/passkey",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@simplewebauthn/browser": "^9.0.0",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeremiemeunier/passkey",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Client-side passkey authentication package with React hook",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
This pull request enhances the system's support for cross-platform passkeys by requiring credentials to be stored as resident keys, enabling users to sync and use passkeys across multiple devices. Documentation has been updated throughout to reflect this improved capability.

**Cross-platform passkey support:**

* Updated the system and documentation to highlight support for cross-platform passkeys, allowing users to create a passkey on one device and use it on another, with syncing via credential managers like iCloud Keychain and Google Password Manager. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R197-R205) [[2]](diffhunk://#diff-c7b1c23e00a1fd0378f6ea41a7dfe1c9e043d766f738dba26860c783b82e8c6aR8)

**WebAuthn configuration changes:**

* Changed `residentKey` from `"preferred"` to `"required"` in the passkey registration options in `PasskeyService`, the API reference, and usage examples to ensure credentials are always stored on authenticators for cross-device use. [[1]](diffhunk://#diff-898d114e6c8c28e73ee122fe4a281eaae74495110ec98d1e930ad172bf7690f4L62-R62) [[2]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cL70-R70) [[3]](diffhunk://#diff-3f168ef45b689fab1e3bf76f5bfa88212fd4e0860b46b353261b213adb4f42eaL92-R92)